### PR TITLE
Remove node-raintank-collector when installing raintank-probe

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -22,5 +22,6 @@ fpm -s dir -t deb \
   -v ${VERSION} -n raintank-probe -a ${ARCH} --description "Raintank Probe" \
   --deb-upstart ${BASE}/etc/init/raintank-probe.conf \
   --replaces node-raintank-collector --provides node-raintank-collector \
+  --conflicts node-raintank-collector \
   -C ${BUILD} -p ${PACKAGE_NAME} .
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -21,5 +21,6 @@ mv ${BUILD}/raintank-probe ${BUILD}/usr/bin/
 fpm -s dir -t deb \
   -v ${VERSION} -n raintank-probe -a ${ARCH} --description "Raintank Probe" \
   --deb-upstart ${BASE}/etc/init/raintank-probe.conf \
+  --replaces node-raintank-collector --provides node-raintank-collector
   -C ${BUILD} -p ${PACKAGE_NAME} .
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -21,6 +21,6 @@ mv ${BUILD}/raintank-probe ${BUILD}/usr/bin/
 fpm -s dir -t deb \
   -v ${VERSION} -n raintank-probe -a ${ARCH} --description "Raintank Probe" \
   --deb-upstart ${BASE}/etc/init/raintank-probe.conf \
-  --replaces node-raintank-collector --provides node-raintank-collector
+  --replaces node-raintank-collector --provides node-raintank-collector \
   -C ${BUILD} -p ${PACKAGE_NAME} .
 


### PR DESCRIPTION
This change in the packaging script will remove the node-raintank-collector package when installing raintank-probe (at least when running a simple `apt-get install raintank-probe` from the command line, without any fancy flags like `-y`). Assuming it behaves the same way with chef, this method will work with the other packages that need replacing.
