### PR TITLE
Error handling & ipv4/v6

### DIFF
--- a/checks/common.go
+++ b/checks/common.go
@@ -1,6 +1,9 @@
 package checks
 
 import (
+	"fmt"
+	"net"
+	"strings"
 	"time"
 
 	m "github.com/raintank/worldping-api/pkg/models"
@@ -10,4 +13,29 @@ import (
 type CheckResult interface {
 	Metrics(time.Time, *m.CheckWithSlug) []*schema.MetricData
 	ErrorMsg() string
+}
+
+func ResolveHost(host, ipversion string) (string, error) {
+	addrs, err := net.LookupHost(host)
+	if err != nil || len(addrs) < 1 {
+		return "", fmt.Errorf("failed to resolve hostname to IP.")
+	}
+
+	for _, addr := range addrs {
+		if ipversion == "any" {
+			return addr, nil
+		}
+
+		if strings.Contains(addr, ":") || strings.Contains(addr, "%") {
+			if ipversion == "v6" {
+				return addr, nil
+			}
+		} else {
+			if ipversion == "v4" {
+				return addr, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("failed to resolve hostname to valid IP.")
 }

--- a/checks/dns.go
+++ b/checks/dns.go
@@ -2,6 +2,8 @@ package checks
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -242,7 +244,7 @@ func (p *RaintankProbeDns) Run() (CheckResult, error) {
 		//trim any leading/training whitespace.
 		server := strings.Trim(s, " ")
 
-		srvPort := fmt.Sprintf("%s:%d", server, p.Port)
+		srvPort := net.JoinHostPort(server, strconv.FormatInt(p.Port, 10))
 		start := time.Now()
 		r, t, err := c.Exchange(&m, srvPort)
 		if err != nil || r == nil {

--- a/checks/http.go
+++ b/checks/http.go
@@ -376,6 +376,7 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 
 	if err != nil {
 		msg := fmt.Sprintf("Invalid request settings. %s", err.Error())
+
 		result.Error = &msg
 		return result, nil
 	}
@@ -386,6 +387,7 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 		dummyRequest, err := http.ReadRequest(headReader)
 		if err != nil {
 			msg := err.Error()
+
 			result.Error = &msg
 			return result, nil
 		}
@@ -411,6 +413,7 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 	addrs, err := net.LookupHost(p.Host)
 	if err != nil || len(addrs) < 1 {
 		msg := "failed to resolve hostname to IP."
+
 		result.Error = &msg
 		return result, nil
 	}
@@ -422,42 +425,43 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 	start := time.Now()
 	conn, err := net.DialTimeout("tcp", net.JoinHostPort(addrs[0], strconv.FormatInt(p.Port, 10)), p.Timeout)
 	if err != nil {
+		msg := ""
 		opError, ok := err.(*net.OpError)
 		if ok {
 			if opError.Timeout() {
-				msg := "timeout while connecting to host."
-				result.Error = &msg
-				return result, nil
+				msg = "timeout while connecting to host."
+			} else {
+				msg = fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
 			}
-			msg := fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
-			result.Error = &msg
-			return result, nil
+		} else {
+			msg = err.Error()
 		}
-		msg := err.Error()
+
 		result.Error = &msg
 		return result, nil
 	}
-	conn.SetDeadline(deadline)
 
+	conn.SetDeadline(deadline)
 	defer conn.Close()
+
 	connecting := time.Since(start).Seconds() * 1000
 	result.Connect = &connecting
 
 	// Send
 	step = time.Now()
 	if err := request.Write(conn); err != nil {
+		msg := ""
 		opError, ok := err.(*net.OpError)
 		if ok {
 			if opError.Timeout() {
-				msg := "timeout while sending request."
-				result.Error = &msg
-				return result, nil
+				msg = "timeout while sending request."
+			} else {
+				msg := fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
 			}
-			msg := fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
-			result.Error = &msg
-			return result, nil
+		} else {
+			msg := err.Error()
 		}
-		msg := err.Error()
+
 		result.Error = &msg
 		return result, nil
 	}
@@ -471,21 +475,24 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 	step = time.Now()
 	response, err := http.ReadResponse(bufio.NewReader(conn), request)
 	if err != nil {
+		msg := ""
 		opError, ok := err.(*net.OpError)
 		if ok {
 			if opError.Timeout() {
-				msg := "timeout while waiting for response."
-				result.Error = &msg
-				return result, nil
+				msg = "timeout while waiting for response."
+			} else {
+				msg = fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
 			}
-			msg := fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
-			result.Error = &msg
-			return result, nil
+		} else {
+			msg = err.Error()
 		}
-		msg := err.Error()
+
 		result.Error = &msg
 		return result, nil
 	}
+
+	defer response.Body.Close()
+
 	wait := time.Since(step).Seconds() * 1000
 	result.Wait = &wait
 
@@ -495,41 +502,44 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 	for {
 		n, err := response.Body.Read(data)
 		body.Write(data[:n])
+		if err == io.EOF {
+			break
+		}
+
 		if err != nil {
-			if err != io.EOF {
-				opError, ok := err.(*net.OpError)
-				if ok {
-					if opError.Timeout() {
-						msg := "timeout while receiving response."
-						result.Error = &msg
-						return result, nil
-					}
-					msg := fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
-					result.Error = &msg
-					return result, nil
+			msg := ""
+
+			opError, ok := err.(*net.OpError)
+			if ok {
+				if opError.Timeout() {
+					msg = "timeout while receiving response."
+				} else {
+					msg = fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
 				}
-				msg := err.Error()
-				result.Error = &msg
-				return result, nil
 			} else {
-				break
+				msg = err.Error()
 			}
+
+			result.Error = &msg
+			return result, nil
 		}
 
 		if int64(body.Len()) > p.DownloadLimit {
-			conn.Close()
 			break
 		}
 	}
 
 	recv := time.Since(step).Seconds() * 1000
+	result.Recv = &recv
+
+	response.Body.Close()
+	conn.Close()
+
 	/*
 		Total time
 	*/
 	total := time.Since(start).Seconds() * 1000
 	result.Total = &total
-
-	result.Recv = &recv
 
 	// Data Length
 	var headers bytes.Buffer
@@ -537,16 +547,10 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 	dataLength := float64(body.Len() + headers.Len())
 	result.DataLength = &dataLength
 
-	//throughput
+	// throughput
 	if recv > 0 {
 		throughput := float64(body.Len()) / (recv / 1000.0)
 		result.Throughput = &throughput
-	}
-
-	if err != nil {
-		msg := err.Error()
-		result.Error = &msg
-		return result, nil
 	}
 
 	// Error response
@@ -554,6 +558,7 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 	result.StatusCode = &statusCode
 	if statusCode >= 400 {
 		msg := "Invalid status code " + strconv.Itoa(response.StatusCode)
+
 		result.Error = &msg
 		return result, nil
 	}
@@ -563,6 +568,7 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 		rgx, err := regexp.Compile(p.ExpectRegex)
 		if err != nil {
 			msg := err.Error()
+
 			result.Error = &msg
 			return result, nil
 		}
@@ -575,12 +581,15 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 			reader, err := gzip.NewReader(&body)
 			if err != nil {
 				msg := err.Error()
+
 				result.Error = &msg
 				return result, nil
 			}
+
 			decodedBodyBytes, err := ioutil.ReadAll(reader)
 			if err != nil && len(decodedBodyBytes) == 0 {
 				msg := err.Error()
+
 				result.Error = &msg
 				return result, nil
 			}
@@ -589,6 +598,7 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 			decodedBody = body.String()
 		default:
 			msg := "unrecognized Content-Encoding: " + response.Header.Get("Content-Encoding")
+
 			result.Error = &msg
 			return result, nil
 		}
@@ -597,6 +607,7 @@ func (p *RaintankProbeHTTP) Run() (CheckResult, error) {
 			log.Debug("expectRegex %s did not match returned body %s", p.ExpectRegex, decodedBody)
 
 			msg := "expectRegex did not match"
+
 			result.Error = &msg
 			return result, nil
 		}

--- a/checks/https.go
+++ b/checks/https.go
@@ -228,6 +228,7 @@ type RaintankProbeHTTPS struct {
 	Body          string        `json:"body"`
 	Timeout       time.Duration `json:"timeout"`
 	DownloadLimit int64         `json:"downloadLimit"`
+	IPVersion     string        `json:"ipversion"`
 }
 
 // NewRaintankHTTPSProbe json check
@@ -370,6 +371,19 @@ func NewRaintankHTTPSProbe(settings map[string]interface{}) (*RaintankProbeHTTPS
 		}
 	}
 
+	version, ok := settings["ipversion"]
+	if !ok {
+		p.IPVersion = "v4"
+	} else {
+		p.IPVersion, ok = version.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid value for ipversion, must be string.")
+		}
+	}
+	if !(p.IPVersion == "v4" || p.IPVersion == "v6" || p.IPVersion == "any") {
+		return nil, fmt.Errorf("ipversion must be v4, v6, or any.")
+	}
+
 	return &p, nil
 }
 
@@ -379,17 +393,18 @@ func (p *RaintankProbeHTTPS) Run() (CheckResult, error) {
 	result := &HTTPSResult{}
 
 	// reader
-	tmpPort := ""
+	tmpHost := p.Host
 	if p.Port != 443 {
-		tmpPort = fmt.Sprintf(":%d", p.Port)
+		tmpHost = net.JoinHostPort(p.Host, strconv.FormatInt(p.Port, 10))
+	} else if strings.Contains(p.Host, ":") || strings.Contains(p.Host, "%") {
+		tmpHost = "[" + p.Host + "]"
 	}
-	url := fmt.Sprintf("https://%s%s%s", p.Host, tmpPort, p.Path)
+	url := fmt.Sprintf("https://%s%s", tmpHost, p.Path)
 	sendBody := bytes.NewReader([]byte(p.Body))
 	request, err := http.NewRequest(p.Method, url, sendBody)
 
 	if err != nil {
 		msg := fmt.Sprintf("Invalid request settings. %s", err.Error())
-
 		result.Error = &msg
 		return result, nil
 	}
@@ -423,10 +438,15 @@ func (p *RaintankProbeHTTPS) Run() (CheckResult, error) {
 
 	// DNS lookup
 	step := time.Now()
-	addrs, err := net.LookupHost(p.Host)
-	if err != nil || len(addrs) < 1 {
-		msg := "failed to resolve hostname to IP."
 
+	ipAddr, err := ResolveHost(p.Host, p.IPVersion)
+	if err != nil {
+		msg := err.Error()
+		result.Error = &msg
+		return result, nil
+	}
+	if time.Now().After(deadline) {
+		msg := "timeout resolving IP address of hostname."
 		result.Error = &msg
 		return result, nil
 	}
@@ -439,9 +459,11 @@ func (p *RaintankProbeHTTPS) Run() (CheckResult, error) {
 		ServerName:         p.Host,
 	}
 
+	// fmt.Printf("https connecting to %#v\n", ipAddr)
+
 	// Dialing
 	start := time.Now()
-	tcpconn, err := net.DialTimeout("tcp", net.JoinHostPort(addrs[0], strconv.FormatInt(p.Port, 10)), p.Timeout)
+	tcpconn, err := net.DialTimeout("tcp", net.JoinHostPort(ipAddr, strconv.FormatInt(p.Port, 10)), p.Timeout)
 	if err != nil {
 		msg := ""
 		opError, ok := err.(*net.OpError)
@@ -485,10 +507,10 @@ func (p *RaintankProbeHTTPS) Run() (CheckResult, error) {
 			if opError.Timeout() {
 				msg = "timeout while sending request."
 			} else {
-				msg := fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
+				msg = fmt.Sprintf("%s error. %s", opError.Op, opError.Err.Error())
 			}
 		} else {
-			msg := err.Error()
+			msg = err.Error()
 		}
 
 		result.Error = &msg
@@ -587,7 +609,6 @@ func (p *RaintankProbeHTTPS) Run() (CheckResult, error) {
 	result.StatusCode = &statusCode
 	if statusCode >= 400 {
 		msg := "Invalid status code " + strconv.Itoa(response.StatusCode)
-
 		result.Error = &msg
 		return result, nil
 	}
@@ -635,7 +656,6 @@ func (p *RaintankProbeHTTPS) Run() (CheckResult, error) {
 			decodedBody = body.String()
 		default:
 			msg := "unrecognized Content-Encoding: " + response.Header.Get("Content-Encoding")
-
 			result.Error = &msg
 			return result, nil
 		}
@@ -644,7 +664,6 @@ func (p *RaintankProbeHTTPS) Run() (CheckResult, error) {
 			log.Debug("expectRegex %s did not match returned body %s", p.ExpectRegex, decodedBody)
 
 			msg := "expectRegex did not match"
-
 			result.Error = &msg
 			return result, nil
 		}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -109,7 +109,7 @@ func (t *Tsdb) Flush() {
 			return
 		}
 		t.dataChan <- tsdbData{Path: "metrics", Body: body}
-		log.Debug("%d metrics queud for delivery", len(batch))
+		log.Debug("%d metrics queued for delivery", len(batch))
 	}
 }
 


### PR DESCRIPTION
With this update probes will attempt to connect via ipv4 unless the check includes an `ipversion` field set to `v6` or `any`