### PR TITLE
fix nilpointer

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -53,7 +53,9 @@ func (i *CheckInstance) Update(c *m.CheckWithSlug, probeHealthy bool) error {
 		return err
 	}
 	i.Lock()
-	i.Ticker.Stop()
+	if i.Ticker != nil {
+		i.Ticker.Stop()
+	}
 	i.Check = c
 	i.Exec = executor
 	i.Unlock()


### PR DESCRIPTION
checkInstances may not have their ticker set yet,
when an update is received.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x48f5d2]

goroutine 25318 [running]:
time.(*Ticker).Stop(0x0)
        /usr/local/go/src/time/tick.go:46 +0x22
github.com/raintank/raintank-probe/scheduler.(*CheckInstance).Update(0xc4259d7c80, 0xc42855c820, 0x22201, 0xc4252bc7d0, 0x1)
        /home/ubuntu/.go_workspace/src/github.com/raintank/raintank-probe/scheduler/scheduler.go:56 +0x99
github.com/raintank/raintank-probe/scheduler.(*Scheduler).Update(0xc420043a00, 0xc42855c820)
        /home/ubuntu/.go_workspace/src/github.com/raintank/raintank-probe/scheduler/scheduler.go:337 +0x198
main.bindHandlers.func4(0xc42010c1f0, 0x2224f, 0x15fd4, 0x9ccf, 0xc4287e9de0, 0xc42237dc50, 0x5, 0x78, 0x3f, 0x1, ...)
        /home/ubuntu/raintank-probe/main.go:192 +0x7e
reflect.Value.call(0x8aaa80, 0xc4215ca0d0, 0x13, 0x945a12, 0x4, 0xc425301f08, 0x2, 0x2, 0x4dac63, 0x8ea940, ...)
        /usr/local/go/src/reflect/value.go:434 +0x91f
reflect.Value.Call(0x8aaa80, 0xc4215ca0d0, 0x13, 0xc425301f08, 0x2, 0x2, 0x5, 0x2da, 0xc4284ae2da)
        /usr/local/go/src/reflect/value.go:302 +0xa4
github.com/graarh/golang-socketio.(*caller).callFunc(0xc421720390, 0xc42010c1f0, 0x8ea940, 0xc42855c750, 0xc42237d9f0, 0x0, 0x0)
        /home/ubuntu/.go_workspace/src/github.com/graarh/golang-socketio/caller.go:74 +0x181
github.com/graarh/golang-socketio.(*methods).processIncomingMessage(0xc42010c1c0, 0xc42010c1f0, 0xc4287ea580)
        /home/ubuntu/.go_workspace/src/github.com/graarh/golang-socketio/handler.go:107 +0x43e
created by github.com/graarh/golang-socketio.inLoop
        /home/ubuntu/.go_workspace/src/github.com/graarh/golang-socketio/loop.go:136 +0xe6
```