### PR TITLE
remove tags from metrics

### DIFF
--- a/checks/dns.go
+++ b/checks/dns.go
@@ -35,66 +35,50 @@ func (r *DnsResult) Metrics(t time.Time, check *m.CheckWithSlug) []*schema.Metri
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.dns.time", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.dns.time",
+			Metric:   fmt.Sprintf("worldping.%s.%s.dns.time", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Time,
+			Tags:     nil,
+			Value:    *r.Time,
 		})
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.dns.default", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.dns.default",
+			Metric:   fmt.Sprintf("worldping.%s.%s.dns.default", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Time,
+			Tags:     nil,
+			Value:    *r.Time,
 		})
 	}
 	if r.Ttl != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.dns.ttl", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.dns.ttl",
+			Metric:   fmt.Sprintf("worldping.%s.%s.dns.ttl", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "s",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: float64(*r.Ttl),
+			Tags:     nil,
+			Value:    float64(*r.Ttl),
 		})
 	}
 	if r.Answers != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.dns.answers", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.dns.time",
+			Metric:   fmt.Sprintf("worldping.%s.%s.dns.answers", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: float64(*r.Answers),
+			Tags:     nil,
+			Value:    float64(*r.Answers),
 		})
 	}
 

--- a/checks/http.go
+++ b/checks/http.go
@@ -47,168 +47,128 @@ func (r *HTTPResult) Metrics(t time.Time, check *m.CheckWithSlug) []*schema.Metr
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.dns", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.dns",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.dns", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.DNS,
+			Tags:     nil,
+			Value:    *r.DNS,
 		})
 	}
 	if r.Connect != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.connect", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.connect",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.connect", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Connect,
+			Tags:     nil,
+			Value:    *r.Connect,
 		})
 	}
 	if r.Send != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.send", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.send",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.send", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Send,
+			Tags:     nil,
+			Value:    *r.Send,
 		})
 	}
 	if r.Wait != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.wait", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.wait",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.wait", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Wait,
+			Tags:     nil,
+			Value:    *r.Wait,
 		})
 	}
 	if r.Recv != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.recv", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.recv",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.recv", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Recv,
+			Tags:     nil,
+			Value:    *r.Recv,
 		})
 	}
 	if r.Total != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.total", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.total",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.total", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Total,
+			Tags:     nil,
+			Value:    *r.Total,
 		})
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.default", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.default",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.default", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Total,
+			Tags:     nil,
+			Value:    *r.Total,
 		})
 	}
 	if r.Throughput != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.throughput", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.throughput",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.throughput", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "B/s",
 			Mtype:    "rate",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Throughput,
+			Tags:     nil,
+			Value:    *r.Throughput,
 		})
 	}
 	if r.DataLength != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.dataLength", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.dataLength",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.dataLength", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "B",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.DataLength,
+			Tags:     nil,
+			Value:    *r.DataLength,
 		})
 	}
 	if r.StatusCode != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.http.statusCode", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.http.statusCode",
+			Metric:   fmt.Sprintf("worldping.%s.%s.http.statusCode", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.StatusCode,
+			Tags:     nil,
+			Value:    *r.StatusCode,
 		})
 	}
 	return metrics

--- a/checks/https.go
+++ b/checks/https.go
@@ -49,185 +49,141 @@ func (r *HTTPSResult) Metrics(t time.Time, check *m.CheckWithSlug) []*schema.Met
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.dns", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.dns",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.dns", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.DNS,
+			Tags:     nil,
+			Value:    *r.DNS,
 		})
 	}
 	if r.Connect != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.connect", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.connect",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.connect", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Connect,
+			Tags:     nil,
+			Value:    *r.Connect,
 		})
 	}
 	if r.Send != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.send", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.send",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.send", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Send,
+			Tags:     nil,
+			Value:    *r.Send,
 		})
 	}
 	if r.Wait != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.wait", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.wait",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.wait", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Wait,
+			Tags:     nil,
+			Value:    *r.Wait,
 		})
 	}
 	if r.Recv != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.recv", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.recv",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.recv", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Recv,
+			Tags:     nil,
+			Value:    *r.Recv,
 		})
 	}
 	if r.Total != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.total", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.total",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.total", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Total,
+			Tags:     nil,
+			Value:    *r.Total,
 		})
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.default", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.default",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.default", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Total,
+			Tags:     nil,
+			Value:    *r.Total,
 		})
 	}
 	if r.Throughput != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.throughput", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.throughput",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.throughput", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "B/s",
 			Mtype:    "rate",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Throughput,
+			Tags:     nil,
+			Value:    *r.Throughput,
 		})
 	}
 	if r.DataLength != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.dataLength", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.dataLength",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.dataLength", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "B",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.DataLength,
+			Tags:     nil,
+			Value:    *r.DataLength,
 		})
 	}
 	if r.StatusCode != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.statusCode", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.statusCode",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.statusCode", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.StatusCode,
+			Tags:     nil,
+			Value:    *r.StatusCode,
 		})
 	}
 	if r.Expiry != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.https.expiry", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.https.expiry",
+			Metric:   fmt.Sprintf("worldping.%s.%s.https.expiry", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Expiry,
+			Tags:     nil,
+			Value:    *r.Expiry,
 		})
 	}
 	return metrics

--- a/checks/ping.go
+++ b/checks/ping.go
@@ -53,117 +53,89 @@ func (r *PingResult) Metrics(t time.Time, check *m.CheckWithSlug) []*schema.Metr
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.ping.loss", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.ping.loss",
+			Metric:   fmt.Sprintf("worldping.%s.%s.ping.loss", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "percent",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Loss,
+			Tags:     nil,
+			Value:    *r.Loss,
 		})
 	}
 	if r.Min != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.ping.min", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.ping.min",
+			Metric:   fmt.Sprintf("worldping.%s.%s.ping.min", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Min,
+			Tags:     nil,
+			Value:    *r.Min,
 		})
 	}
 	if r.Max != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.ping.max", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.ping.max",
+			Metric:   fmt.Sprintf("worldping.%s.%s.ping.max", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Max,
+			Tags:     nil,
+			Value:    *r.Max,
 		})
 	}
 	if r.Median != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.ping.median", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.ping.median",
+			Metric:   fmt.Sprintf("worldping.%s.%s.ping.median", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Median,
+			Tags:     nil,
+			Value:    *r.Median,
 		})
 	}
 	if r.Mdev != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.ping.mdev", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.ping.mdev",
+			Metric:   fmt.Sprintf("worldping.%s.%s.ping.mdev", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Mdev,
+			Tags:     nil,
+			Value:    *r.Mdev,
 		})
 	}
 	if r.Avg != nil {
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.ping.mean", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.ping.mean",
+			Metric:   fmt.Sprintf("worldping.%s.%s.ping.mean", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Avg,
+			Tags:     nil,
+			Value:    *r.Avg,
 		})
 		metrics = append(metrics, &schema.MetricData{
 			OrgId:    int(check.OrgId),
 			Name:     fmt.Sprintf("worldping.%s.%s.ping.default", check.Slug, probe.Self.Slug),
-			Metric:   "worldping.ping.default",
+			Metric:   fmt.Sprintf("worldping.%s.%s.ping.default", check.Slug, probe.Self.Slug),
 			Interval: int(check.Frequency),
 			Unit:     "ms",
 			Mtype:    "gauge",
 			Time:     t.Unix(),
-			Tags: []string{
-				fmt.Sprintf("endpoint:%s", check.Slug),
-				fmt.Sprintf("monitor_type:%s", check.Type),
-				fmt.Sprintf("probe:%s", probe.Self.Slug),
-			},
-			Value: *r.Avg,
+			Tags:     nil,
+			Value:    *r.Avg,
 		})
 	}
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -190,31 +190,23 @@ func (c *CheckInstance) run(t time.Time) {
 	metrics = append(metrics, &schema.MetricData{
 		OrgId:    int(c.Check.OrgId),
 		Name:     fmt.Sprintf("worldping.%s.%s.%s.ok_state", c.Check.Slug, probe.Self.Slug, c.Check.Type),
-		Metric:   fmt.Sprintf("worldping.%s.ok_state", c.Check.Type),
+		Metric:   fmt.Sprintf("worldping.%s.%s.%s.ok_state", c.Check.Slug, probe.Self.Slug, c.Check.Type),
 		Interval: int(c.Check.Frequency),
 		Unit:     "state",
 		Mtype:    "gauge",
 		Time:     t.Unix(),
-		Tags: []string{
-			fmt.Sprintf("endpoint:%s", c.Check.Slug),
-			fmt.Sprintf("monitor_type:%s", c.Check.Type),
-			fmt.Sprintf("probe:%s", probe.Self.Slug),
-		},
-		Value: okState,
+		Tags:     nil,
+		Value:    okState,
 	}, &schema.MetricData{
 		OrgId:    int(c.Check.OrgId),
 		Name:     fmt.Sprintf("worldping.%s.%s.%s.error_state", c.Check.Slug, probe.Self.Slug, c.Check.Type),
-		Metric:   fmt.Sprintf("worldping.%s.error_state", c.Check.Type),
+		Metric:   fmt.Sprintf("worldping.%s.%s.%s.error_state", c.Check.Slug, probe.Self.Slug, c.Check.Type),
 		Interval: int(c.Check.Frequency),
 		Unit:     "state",
 		Mtype:    "gauge",
 		Time:     t.Unix(),
-		Tags: []string{
-			fmt.Sprintf("endpoint:%s", c.Check.Slug),
-			fmt.Sprintf("monitor_type:%s", c.Check.Type),
-			fmt.Sprintf("probe:%s", probe.Self.Slug),
-		},
-		Value: errState,
+		Tags:     nil,
+		Value:    errState,
 	})
 
 	for _, m := range metrics {


### PR DESCRIPTION
- tags are not currently used at query time.  With recent changes
  to metrictank (the TSDB), including these tags will result prevent
  the path based series names from working.